### PR TITLE
GCC 4.9 Fix for GMP Compilation Issues

### DIFF
--- a/xptMiner/.gitignore
+++ b/xptMiner/.gitignore
@@ -212,3 +212,7 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+# Compiled files
+*.o
+xptminer

--- a/xptMiner/xptMiner/global.h
+++ b/xptMiner/xptMiner/global.h
@@ -19,6 +19,7 @@
 #else
 
 #ifndef USE_MPIR
+#include <cstddef>
 #include <gmpxx.h>
 #include <gmp.h>
 #else


### PR DESCRIPTION
Changed global.h to expressly import cstddef.  This is to fix an issue with the referenced version of GMP which incorrectly uses C++ macros causing compilation fail on GCC 4.9.

Also modified .gitignore to ignore binaries from builds

Fixes compilation error:

/usr/include/c++/4.9.0/cstddef:51:11: error: ‘::max_align_t’ has not been declared


Reference: https://gcc.gnu.org/gcc-4.9/porting_to.html